### PR TITLE
Add stratify strategy in tain_test_split

### DIFF
--- a/transplant/tools/dataset.py
+++ b/transplant/tools/dataset.py
@@ -74,6 +74,7 @@ class Dataset:
     def _split_data(self, df):
 
         train_df, test_df = train_test_split(df,
+                                             stratify=df['target'],
                                              test_size=0.3,
                                              random_state=self._random_state)
 


### PR DESCRIPTION
Le split du `train` `test` est trop hasardeux dans la répartition des classes [0, 1] : 

```
# Lecture du fichier static (cf get_static()) 
data = pd.read_csv(PATH_STATIC_CLEAN)

## Résultat actuelle : 

train_df, test_df = train_test_split(data, test_size=0.3, random_state=1)

print(train_df.target.value_counts(normalize=True)) 
print(test_df.target.value_counts(normalize=True))

#0    0.592334
#1    0.407666
#Name: target, dtype: float64
#0    0.577236
#1    0.422764
#Name: target, dtype: float64

# Si on change notre random_state

train_df, test_df = train_test_split(data, test_size=0.3, random_state=2018)

print(train_df.target.value_counts(normalize=True)) 
print(test_df.target.value_counts(normalize=True))

#0    0.56446
#1    0.43554
#Name: target, dtype: float64
#0    0.642276
#1    0.357724
#Name: target, dtype: float64
```

On ne respecte pas la proportion des classes dans notre split. Notre résultat aujourd'hui est hasardeux même si il respecte assez bien les proportion de 0 et 1.

## Solution :  

Ajout de `stratify=data['target']` afin de garantir la même proportion de classe dans notre `train`et `test`