### PR TITLE
[Data Quality] Remove duplicate rows from dynamic_clean

### DIFF
--- a/transplant/data/build_clean_from_raw_data.py
+++ b/transplant/data/build_clean_from_raw_data.py
@@ -103,7 +103,10 @@ def clean_dynamic_raw(df_dynamic, df_static):
                    if col.startswith('Unnamed:')]
     df_dynamic = df_dynamic.drop(columns=col_to_drop)
     df_dynamic = df_dynamic.dropna(subset=['foreign_key', 'date'])
-
+    # Drop duplicates rows, we can't have duplicated {patients, timestamp}
+    # See https://github.com/dataforgoodfr/batch_5_transplant/issues/72
+    df_dynamic.drop_duplicates(subset=['foreign_key', 'date', 'time'],
+                               inplace=True)
     # Format dtypes
     df_dynamic = cast_integers(df_dynamic)
 


### PR DESCRIPTION
## Wut? 

Suite à - https://github.com/dataforgoodfr/batch_5_transplant/issues/72, cette PR supprime les doublons dans les fichiers dynamiques source en se basant sur les clés `{'foreign_key', 'date', 'time'}' . 

## Test 

<img width="1106" alt="screen shot 2019-01-22 at 10 18 24 pm" src="https://user-images.githubusercontent.com/695006/51566290-7ea13d00-1e94-11e9-8eba-091a6c3ae86b.png">
