### PR TITLE
Update requirements.txt - Pierre Env ML analysis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,15 @@
 -e .
 
 # external requirements
+
+Keras==2.2.4
+matplotlib==3.0.2
 numpy==1.15.4
-pandas==0.23.4
-plotly==3.2.1
+pandas==0.24.0              # pandas==0.23.4 
+plotly==3.5.0               # plotly==3.2.1
+scikit-learn==0.20.2
+seaborn==0.9.0
+statsmodels==0.9.0
+tensorboard==1.12.2
+tensorflow==1.12.0          # Attention tensorflow ne fonctionne pas encore avec python 3.7 ! 
+                            # J'utilise python 3.6.8 


### PR DESCRIPTION
Il peut y avoir un conflict de version sur pandas et plotly (en commentaire les anciennes versions du requirements.txt) : 

pandas==0.24.0              # pandas==0.23.4 
plotly==3.5.0               # plotly==3.2.1

J'utilise les versions les plus récentes mais je suis presque sûr que les notebooks en PR fonctionnent sous ces anciennes versions.

pip freeze n'a pas spécifié la version de python que j'utilise mais c'est la 3.6.8 ( Important de ne pas utiliser 3.7 sinon tensorflow ne fonctionne pas !)